### PR TITLE
fix: eslint 8.57.0 filenames array

### DIFF
--- a/lib/register.js
+++ b/lib/register.js
@@ -2,8 +2,18 @@
  * This file add a Node CJS register hook to kinda hijack ESLint's internal module
  * to add `.mjs`, `.cjs`, `.ts`, `.cts`, and `.mts` support.
  *
- * @info Last tested on ESLint 8.55.0
- * @commit 3a22236f8d10af8a5bcafe56092651d3d681c99d
+ * @info Last tested on ESLint 8.57.0
+ * @commit 1813aecc4660582b0678cf32ba466eb9674266c4 - 8.57.0
+ * @commit 3a22236f8d10af8a5bcafe56092651d3d681c99d - 8.56.0
+ *
+ * @info Fix for 8.57.0 change of `FLAT_CONFIG_FILENAME` to `FLAT_CONFIG_FILENAMES[]`
+ * @commit dca7d0f1c262bc72310147bcefe1d04ecf60acbc
+ *         feat: Enable eslint.config.mjs and eslint.config.cjs (#18066)
+ *
+ * @info Seems like a solution will also go straight into ESLint soon:
+ *       (2024-02-22) feat: Add support for TS config files #18134
+ *       https://github.com/eslint/eslint/pull/18134
+ *
  */
 const Module = require('node:module')
 const fs = require('node:fs')
@@ -17,13 +27,28 @@ const replacers = [
     path: '/eslint/lib/eslint/flat-eslint.js',
     replace: content => content
       /**
-       * https://github.com/eslint/eslint/blob/3a22236f8d10af8a5bcafe56092651d3d681c99d/lib/eslint/flat-eslint.js#L94
-       *
        * This allows ESLint to scan for `.mjs`, `.cjs`, `.ts`, `.cts`, and `.mts` files as the trigger of Flat Config.
+       *
+       * Will match for <= v8.56.0
+       * https://github.com/eslint/eslint/blob/3a22236f8d10af8a5bcafe56092651d3d681c99d/lib/eslint/flat-eslint.js#L94
        */
       .replace(
         'const FLAT_CONFIG_FILENAME = "eslint.config.js";',
         'const FLAT_CONFIG_FILENAME = ["eslint.config.js", "eslint.config.mjs", "eslint.config.cjs", "eslint.config.ts", "eslint.config.mts", "eslint.config.cts"];',
+      )
+      /**
+       * Will match for >= v8.57
+       * https://github.com/eslint/eslint/blob/1813aecc4660582b0678cf32ba466eb9674266c4/lib/eslint/flat-eslint.js#L94
+       */
+      .replace(
+        [
+          'const FLAT_CONFIG_FILENAMES = [',
+          '    "eslint.config.js",',
+          '    "eslint.config.mjs",',
+          '    "eslint.config.cjs"',
+          '];',
+        ].join('\n'),
+        'const FLAT_CONFIG_FILENAMES = ["eslint.config.js", "eslint.config.mjs", "eslint.config.cjs", "eslint.config.ts", "eslint.config.mts", "eslint.config.cts"];',
       )
       /**
        * https://github.com/eslint/eslint/blob/3a22236f8d10af8a5bcafe56092651d3d681c99d/lib/eslint/flat-eslint.js#L299

--- a/lib/register.js
+++ b/lib/register.js
@@ -41,13 +41,7 @@ const replacers = [
        * https://github.com/eslint/eslint/blob/1813aecc4660582b0678cf32ba466eb9674266c4/lib/eslint/flat-eslint.js#L94
        */
       .replace(
-        [
-          'const FLAT_CONFIG_FILENAMES = [',
-          '    "eslint.config.js",',
-          '    "eslint.config.mjs",',
-          '    "eslint.config.cjs"',
-          '];',
-        ].join('\n'),
+        /const FLAT_CONFIG_FILENAMES = \[[\s\n]*"eslint.config.js",[\s\n]*"eslint.config.mjs",[\s\n]*"eslint.config.cjs"[\s\n]*\];/,
         'const FLAT_CONFIG_FILENAMES = ["eslint.config.js", "eslint.config.mjs", "eslint.config.cjs", "eslint.config.ts", "eslint.config.mts", "eslint.config.cts"];',
       )
       /**


### PR DESCRIPTION
### Description

Fix for ESLint's 8.57.0 change of `FLAT_CONFIG_FILENAME` to `FLAT_CONFIG_FILENAMES[]`
https://github.com/eslint/eslint/blob/1813aecc4660582b0678cf32ba466eb9674266c4/lib/eslint/flat-eslint.js#L94


### Linked Issues

Seems like a solution's going straight into ESLint soon
[2024-02-22: PR > feat: Add support for TS config files #18134](https://github.com/eslint/eslint/pull/18134)


### Additional context

Btw., in `package.json`, `eslint` is given in both, `dependencies` and `devDependencies`, is this by purpose?

```json
"dependencies": {
    "debug": "^4.3.4",
    "eslint": "^8.56.0",
    "jiti": "^1.21.0"
  },
  "devDependencies": {
    ...
    "eslint": "^8.56.0",
}
```

And for anyone who comes here in the time between - instead of this patch, can also use an override in your `package.json`:

PNPM
```json
{
  "pnpm": {
    "overrides": {
      "eslint": "8.56.0",
    }
  }
}
```

Bun and others
```json
{
  "overrides": {
    "eslint": "8.56.0",
  }
}
```