### PR TITLE
fix(tsx): use `__filename` for `tsImport`

### DIFF
--- a/lib/register.js
+++ b/lib/register.js
@@ -30,9 +30,7 @@ const loaders = {
   ],
   'tsx': [
     '  const { tsImport } = await import("tsx/esm/api");',
-    '  const { pathToFileURL } = require("url");',
-    '  console.log(fileURL.pathname, pathToFileURL(__filename));',
-    '  config = await tsImport(fileURL.pathname, pathToFileURL(__filename).pathname);',
+    '  config = await tsImport(fileURL.pathname, __filename);',
   ],
   'bundle-require': [
     '  const { bundleRequire } = await import("bundle-require");',


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
You should be able to pass in `__filename` to `tsImport()`:
https://tsx.is/node#commonjs-usage

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

Curious what the ["Not yet working well in VS Code extension"](https://github.com/antfu/eslint-ts-patch#:~:text=Not%20yet%20working%20well%20in%20VS%20Code%20extension%2C) mentioned in the README is referring to. How can I reproduce?